### PR TITLE
Add CI & DockerHub badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # plugin-surge-preview
 
 [![Build status](https://ci.woodpecker-ci.org/api/badges/woodpecker-ci/plugin-surge-preview/status.svg)](https://ci.woodpecker-ci.org/woodpecker-ci/plugin-surge-preview)
-[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/woodpeckerci/plugin-surge-preview?label=DockerHub%20latest%20version)](https://hub.docker.com/r/woodpeckerci/plugin-surge-preview/tags)
+[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/woodpeckerci/plugin-surge-preview?label=DockerHub%20latest%20version&sort=semver)](https://hub.docker.com/r/woodpeckerci/plugin-surge-preview/tags)
 
 Woodpecker plugin to deploy static pages for reviewing to [surge.sh](https://surge.sh/).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # plugin-surge-preview
 
+[![Build status](https://ci.woodpecker-ci.org/api/badges/woodpecker-ci/plugin-surge-preview/status.svg)](https://ci.woodpecker-ci.org/woodpecker-ci/plugin-surge-preview)
+[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/woodpeckerci/plugin-surge-preview?label=DockerHub%20latest%20version)](https://hub.docker.com/r/woodpeckerci/plugin-surge-preview/tags)
+
 Woodpecker plugin to deploy static pages for reviewing to [surge.sh](https://surge.sh/).
 
 ## Build


### PR DESCRIPTION
The DockerHub badge will show the Docker Image Version (latest by date). If you want to display something else, have a look at what other options are available on [shields.io](https://shields.io/).