### PR TITLE
Use new env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "pipeline-event",
 			Usage:   "event of the current pipeline",
-			EnvVars: []string{"CI_BUILD_EVENT"},
+			EnvVars: []string{"CI_PIPELINE_EVENT", "CI_BUILD_EVENT"},
 		},
 		&cli.StringFlag{
 			Name:    "repo-owner",


### PR DESCRIPTION
That's the reason why our `deploy-preview` step always fails...

@anbraten @6543 After merging this, please release a new version and update the version on ci.woodpecker-ci.org.