### PR TITLE
fix: allow plugin to run on forgejo forges

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -42,7 +42,13 @@ func (p *Plugin) Exec(ctx context.Context) error {
 	}
 
 	p.comment = &comment{}
-	err := p.comment.Load(p.ForgeType, p.ForgeURL, p.ForgeRepoToken)
+
+	driver := p.ForgeType
+	// https://github.com/jenkins-x/go-scm does not understand forgejo.
+	if driver == "forgejo" {
+		driver = "gitea"
+	}
+	err := p.comment.Load(driver, p.ForgeURL, p.ForgeRepoToken)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- github.com/jenkins-x/go-scm does not support forgejo as a forge, this is causing `Unsupported $GIT_KIND value: forgejo` errors when this plugin is being run a Forgejo forge, ex: https://ci.codeberg.org/repos/46/pipeline/417/8.
- Instead of passing "forgejo", pass "gitea". The APIs being used aren't different in forgejo, this should allow forgejo forges to run this plugin again.